### PR TITLE
feat: allow sorting collections / missing by id (descending)

### DIFF
--- a/app/routes/player.$id._index.tsx
+++ b/app/routes/player.$id._index.tsx
@@ -20,6 +20,7 @@ const normalizeSort = (sort: string | null) => {
   switch (sort) {
     case "rank":
     case "quantity":
+    case "itemid":
       return sort;
     default:
       return "name";
@@ -34,6 +35,8 @@ const sortToOrderByQuery = (
       return { rank: "asc" };
     case "quantity":
       return { quantity: "desc" };
+    case "itemid":
+      return { item: { itemid: "desc" } };
     default:
       return { item: { name: "asc" } };
   }
@@ -116,6 +119,14 @@ export default function Player() {
               variant={sort === "quantity" ? "solid" : "outline"}
               to={`/player/${player.playerid}?sort=quantity`}
               icon={<>🔢</>}
+            />
+            <IconButton
+              as={RemixLink}
+              aria-label="Sort by item id"
+              title="Sort by item id"
+              variant={sort === "itemid" ? "solid" : "outline"}
+              to={`/player/${player.playerid}?sort=itemid`}
+              icon={<>🏷️</>}
             />
           </ButtonGroup>
         </ButtonGroup>


### PR DESCRIPTION
Untested (I never set up the fake data for the database), but it's mostly code copied from elsewhere so I expect it to work.

Give the option to sort by item id, descending. This puts the newer items (the more interesting ones) at the top.

I picked 🏷️ for the icon because it felt like a decent pick (id? identifier?) but it's not great so I'll take any other suggestions.