### PR TITLE
feat: add API for player collections

### DIFF
--- a/app/routes/api.player.$id.ts
+++ b/app/routes/api.player.$id.ts
@@ -1,0 +1,31 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { prisma } from "~/lib/prisma.server";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const id = Number(params.id);
+
+  const player = await prisma.player.findUnique({
+    where: { playerid: id },
+    select: {
+      playerid: true,
+      name: true,
+      collections: {
+        select: {
+          quantity: true,
+          rank: true,
+          itemid: true,
+        },
+        orderBy: { itemid: "asc" },
+      },
+      nameChanges: {
+        orderBy: { when: "desc" },
+      },
+    },
+  });
+
+  if (!player) throw json("Player not found with that id", { status: 404 });
+
+  return json(player);
+}
+


### PR DESCRIPTION
By https://kolmafia.us/threads/json.28747/#post-174736 frono is using Remix implementation details as an API. Make an actual API.

Don't return full item details as they're unnecessary.