### PR TITLE
feat: add 'itemdata' API route for mafia use

### DIFF
--- a/app/routes/api.itemdata.ts
+++ b/app/routes/api.itemdata.ts
@@ -2,7 +2,26 @@ import { db } from "~/db.server";
 
 export async function loader() {
   const items = await db.item.findMany({
-    select: { itemid: true, name: true, picture: true, descid: true, type: true, itemclass: true, candiscard: true, cantransfer: true, quest: true, gift: true, smith: true, cook: true, cocktail: true, jewelry: true, multiuse: true, sellvalue: true, power: true, plural: true },
+    select: {
+      itemid: true,
+      name: true,
+      picture: true,
+      descid: true,
+      type: true,
+      itemclass: true,
+      candiscard: true,
+      cantransfer: true,
+      quest: true,
+      gift: true,
+      smith: true,
+      cook: true,
+      cocktail: true,
+      jewelry: true,
+      multiuse: true,
+      sellvalue: true,
+      power: true,
+      plural: true,
+    },
     where: { missing: false },
     orderBy: { itemid: "asc" },
   });

--- a/app/routes/api.itemdata.ts
+++ b/app/routes/api.itemdata.ts
@@ -1,0 +1,33 @@
+import { db } from "~/db.server";
+
+export async function loader() {
+  const items = await db.item.findMany({
+    select: { itemid: true, name: true, picture: true, descid: true, type: true, itemclass: true, candiscard: true, cantransfer: true, quest: true, gift: true, smith: true, cook: true, cocktail: true, jewelry: true, multiuse: true, sellvalue: true, power: true, quest2: true, plural: true },
+    where: { missing: false },
+    orderBy: { itemid: "asc" },
+  });
+
+  return Response.json(
+    items.map((i) => ({
+      id: i.itemid,
+      name: i.name,
+      descid: i.descid,
+      image: i.picture,
+      type: i.type,
+      itemclass: i.itemclass,
+      power: i.power,
+      multiple: i.multiuse,
+      smith: i.smith,
+      cook: i.cook,
+      mix: i.cocktail,
+      jewelry: i.jewelry,
+      d: i.candiscard,
+      t: i.cantransfer,
+      q: i.quest,
+      q2: i.quest2,
+      g: i.gift,
+      autosell: i.sellvalue,
+      plural: i.plural ?? undefined,
+    })),
+  );
+}

--- a/app/routes/api.itemdata.ts
+++ b/app/routes/api.itemdata.ts
@@ -2,7 +2,7 @@ import { db } from "~/db.server";
 
 export async function loader() {
   const items = await db.item.findMany({
-    select: { itemid: true, name: true, picture: true, descid: true, type: true, itemclass: true, candiscard: true, cantransfer: true, quest: true, gift: true, smith: true, cook: true, cocktail: true, jewelry: true, multiuse: true, sellvalue: true, power: true, quest2: true, plural: true },
+    select: { itemid: true, name: true, picture: true, descid: true, type: true, itemclass: true, candiscard: true, cantransfer: true, quest: true, gift: true, smith: true, cook: true, cocktail: true, jewelry: true, multiuse: true, sellvalue: true, power: true, plural: true },
     where: { missing: false },
     orderBy: { itemid: "asc" },
   });
@@ -24,7 +24,6 @@ export async function loader() {
       d: i.candiscard,
       t: i.cantransfer,
       q: i.quest,
-      q2: i.quest2,
       g: i.gift,
       autosell: i.sellvalue,
       plural: i.plural ?? undefined,

--- a/app/routes/api.itemdata.ts
+++ b/app/routes/api.itemdata.ts
@@ -22,7 +22,7 @@ export async function loader() {
       power: true,
       plural: true,
     },
-    where: { missing: false },
+    where: { missing: false, seen: { isNot: null } },
     orderBy: { itemid: "asc" },
   });
 


### PR DESCRIPTION
Like plural, but contains more things we want to see in items.txt, translated to appear more like they do in Mafia.

Aims to be a faster way to check old data in items.txt than loading `desc_item` for every single item. We would have to do that anyway for things like modifiers, but this lets us check most of it. As-is, changes aren't picked up.

Not sure of the difference between `quest` and `quest2` or which of `type` and `itemclass` is the one we care about (or neither). Include both so we can sort it out on the Mafia side.