### PR TITLE
fix: avoid non-public items in next / prev

### DIFF
--- a/app/routes/item.$id.tsx
+++ b/app/routes/item.$id.tsx
@@ -17,11 +17,11 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
     return {
       item: await loadCollections(id),
       prev: await db.item.findFirst({
-        where: { itemid: { lt: id }, seen: { isNot: null } },
+        where: { itemid: { lt: id }, seen: { isNot: null }, missing: false },
         orderBy: { itemid: "desc" },
       }),
       next: await db.item.findFirst({
-        where: { itemid: { gt: id }, seen: { isNot: null } },
+        where: { itemid: { gt: id }, seen: { isNot: null }, missing: false },
         orderBy: { itemid: "asc" },
       }),
     };


### PR DESCRIPTION
Hopefully fix "prev" on https://museum.loathers.net/item/1224 leading to pimonkey item.