### PR TITLE
Avoid missing items in prev/next navigation

### DIFF
--- a/app/routes/item.$id.tsx
+++ b/app/routes/item.$id.tsx
@@ -37,6 +37,7 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
         .innerJoin("ItemSeen", "ItemSeen.itemid", "Item.itemid")
         .select(["Item.itemid", "Item.name", "Item.ambiguous"])
         .where("Item.itemid", "<", itemId)
+        .where("Item.missing", "=", false)
         .orderBy("Item.itemid", "desc")
         .limit(1)
         .executeTakeFirst(),
@@ -45,6 +46,7 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
         .innerJoin("ItemSeen", "ItemSeen.itemid", "Item.itemid")
         .select(["Item.itemid", "Item.name", "Item.ambiguous"])
         .where("Item.itemid", ">", itemId)
+        .where("Item.missing", "=", false)
         .orderBy("Item.itemid", "asc")
         .limit(1)
         .executeTakeFirst(),


### PR DESCRIPTION
## Summary

- Adds `missing = false` filter to the prev/next item queries on the item page
- Fixes the issue from #24 (now rebased onto the Kysely migration)

## Test plan

- [ ] Navigate to an item whose neighbours include a missing/filler item and confirm prev/next skips it